### PR TITLE
chore: restore version to default since ci will update it automatically before publish

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "system",
   "name": "ten_ai_base",
-  "version": "0.2.3",
+  "version": "0.1.0",
   "package": {
     "include": [
       "manifest.json",


### PR DESCRIPTION
No need to update version manually anymore.