### PR TITLE
feat: add provide_features event for module feature reporting

### DIFF
--- a/api/asr-interface.json
+++ b/api/asr-interface.json
@@ -223,6 +223,20 @@
             ]
         },
         {
+            "name": "provide_features",
+            "property": {
+                "properties": {
+                    "features": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            },
+            "required": [
+                "features"
+            ]
+        },
+        {
             "name": "connection_status_changed",
             "property": {
                 "properties": {

--- a/api/avatar-interface.json
+++ b/api/avatar-interface.json
@@ -140,6 +140,20 @@
         "vendor",
         "metrics"
       ]
+    },
+    {
+      "name": "provide_features",
+      "property": {
+        "properties": {
+          "features": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      },
+      "required": [
+        "features"
+      ]
     }
   ]
 }

--- a/api/llm-interface.json
+++ b/api/llm-interface.json
@@ -176,6 +176,20 @@
                 "code",
                 "message"
             ]
+        },
+        {
+            "name": "provide_features",
+            "property": {
+                "properties": {
+                    "features": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            },
+            "required": [
+                "features"
+            ]
         }
     ]
 }

--- a/api/mllm-interface.json
+++ b/api/mllm-interface.json
@@ -277,6 +277,20 @@
                 "vendor",
                 "metrics"
             ]
+        },
+        {
+            "name": "provide_features",
+            "property": {
+                "properties": {
+                    "features": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            },
+            "required": [
+                "features"
+            ]
         }
     ]
 }

--- a/api/tts-interface.json
+++ b/api/tts-interface.json
@@ -306,6 +306,20 @@
                 "vendor",
                 "metrics"
             ]
+        },
+        {
+            "name": "provide_features",
+            "property": {
+                "properties": {
+                    "features": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            },
+            "required": [
+                "features"
+            ]
         }
     ],
     "cmd_in": [

--- a/interface/ten_ai_base/__init__.py
+++ b/interface/ten_ai_base/__init__.py
@@ -45,8 +45,10 @@ from .message import (
     ModuleType,
     ErrorMessage,
     MetricsMessage,
+    ProvideFeaturesPayload,
     VENDOR_METADATA_KEY,
 )
+from .features import send_provide_features
 from .dumper import Dumper
 from .reconnect_manager import ReconnectManager
 from .connection_status import ConnectionStatusMachine, ConnectionStatusTransition
@@ -101,7 +103,9 @@ __all__ = [
     "ModuleType",
     "ErrorMessage",
     "MetricsMessage",
+    "ProvideFeaturesPayload",
     "VENDOR_METADATA_KEY",
+    "send_provide_features",
     "Dumper",
     "ReconnectManager",
     "ConnectionStatusMachine",

--- a/interface/ten_ai_base/asr.py
+++ b/interface/ten_ai_base/asr.py
@@ -23,6 +23,7 @@ from .message import (
     VENDOR_METADATA_KEY,
 )
 from .connection_status import ConnectionStatusMachine, ConnectionStatusTransition
+from .features import send_provide_features
 from .timeline import AudioTimeline
 from .utils import redact_json
 from .const import (
@@ -135,6 +136,11 @@ class AsyncASRBaseExtension(AsyncExtension):
 
     async def on_start(self, ten_env: AsyncTenEnv) -> None:
         ten_env.log_info("on_start")
+
+        await send_provide_features(
+            ten_env,
+            {"asr.vendor": self.vendor()},
+        )
 
         # Create a task to send audio actual send metrics
         self.audio_actual_send_metrics_task = asyncio.create_task(

--- a/interface/ten_ai_base/const.py
+++ b/interface/ten_ai_base/const.py
@@ -33,6 +33,7 @@ DATA_IN_ASR_FINALIZE = "asr_finalize"
 DATA_IN_TRIGGER_CONNECT = "trigger_connect"
 DATA_OUT_ASR_FINALIZE_END = "asr_finalize_end"
 DATA_OUT_METRICS = "metrics"
+DATA_OUT_PROVIDE_FEATURES = "provide_features"
 DATA_OUT_CONNECTION_STATUS_CHANGED = "connection_status_changed"
 
 PROPERTY_KEY_METADATA = "metadata"

--- a/interface/ten_ai_base/features.py
+++ b/interface/ten_ai_base/features.py
@@ -1,0 +1,20 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+from typing import Any, Mapping
+
+from ten_runtime import AsyncTenEnv, Data
+
+from .const import DATA_OUT_PROVIDE_FEATURES
+from .message import ProvideFeaturesPayload
+
+
+async def send_provide_features(
+    ten_env: AsyncTenEnv, features: Mapping[str, Any]
+) -> None:
+    data = Data.create(DATA_OUT_PROVIDE_FEATURES)
+    payload = ProvideFeaturesPayload(features=dict(features))
+    data.set_property_from_json(None, payload.model_dump_json())
+    await ten_env.send_data(data)

--- a/interface/ten_ai_base/message.py
+++ b/interface/ten_ai_base/message.py
@@ -83,6 +83,10 @@ class ModuleMetrics(BaseModel):
     metadata: dict[str, Any] = {}
 
 
+class ProvideFeaturesPayload(BaseModel):
+    features: dict[str, Any]
+
+
 class ModuleConnectionStatusChanged(BaseModel):
     id: str = ""        # uuid
     module: str = ""    # module type

--- a/interface/ten_ai_base/tts2.py
+++ b/interface/ten_ai_base/tts2.py
@@ -11,6 +11,7 @@ import traceback
 import uuid
 
 from .helper import AsyncQueue
+from .features import send_provide_features
 from .message import (
     ModuleError,
     ModuleMetricKey,
@@ -169,6 +170,10 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
 
     async def on_start(self, ten_env: AsyncTenEnv) -> None:
         await super().on_start(ten_env)
+        await send_provide_features(
+            ten_env,
+            {"tts.vendor": self.vendor()},
+        )
         if self.loop_task is None:
             self.loop = asyncio.get_event_loop()
             self.loop_task = self.loop.create_task(self._process_input_queue(ten_env))

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "system",
   "name": "ten_ai_base",
-  "version": "0.7.48",
+  "version": "0.7.49",
   "package": {
     "include": [
       "manifest.json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,9 @@
 [project]
 name = "ten_ai_base"
-version = "0.1.0"
+version = "0.7.49"
 description = "TEN Framework base AI module"
 requires-python = ">=3.10"
-dependencies = [
-    "aiofiles>=25.1.0",
-    "pydantic>=2",
-    "typing-extensions>=4.15.0",
-]
+dependencies = ["aiofiles>=25.1.0", "pydantic>=2", "typing-extensions>=4.15.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_feature_reporting.py
+++ b/tests/test_feature_reporting.py
@@ -1,0 +1,320 @@
+#
+# Copyright © 2025 Agora
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0, with certain conditions.
+# Refer to the "LICENSE" file in the root directory for more information.
+#
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _create_fake_ten_runtime_modules() -> dict[str, types.ModuleType]:
+    ten_runtime = types.ModuleType("ten_runtime")
+
+    class AsyncTenEnv:
+        pass
+
+    class AsyncExtension:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def on_init(self, ten_env) -> None:
+            return None
+
+        async def on_start(self, ten_env) -> None:
+            return None
+
+        async def on_stop(self, ten_env) -> None:
+            return None
+
+        async def on_deinit(self, ten_env) -> None:
+            return None
+
+    class Data:
+        def __init__(self, name: str) -> None:
+            self._name = name
+            self._json_properties: dict[str | None, str] = {}
+
+        @staticmethod
+        def create(name: str):
+            return Data(name)
+
+        def get_name(self) -> str:
+            return self._name
+
+        def set_property_from_json(self, key, value) -> None:
+            self._json_properties[key] = value
+
+        def get_property_to_json(self, key):
+            return self._json_properties[key], None
+
+    class AudioFrame:
+        @staticmethod
+        def create(name: str):
+            return types.SimpleNamespace(name=name)
+
+    class AudioFrameDataFmt:
+        INTERLEAVE = "interleave"
+
+    class Cmd:
+        pass
+
+    class CmdResult:
+        @staticmethod
+        def create(status_code, cmd):
+            return types.SimpleNamespace(status_code=status_code, cmd=cmd)
+
+    class StatusCode:
+        OK = "ok"
+        ERROR = "error"
+
+    ten_runtime.AsyncTenEnv = AsyncTenEnv
+    ten_runtime.AsyncExtension = AsyncExtension
+    ten_runtime.Data = Data
+    ten_runtime.AudioFrame = AudioFrame
+    ten_runtime.AudioFrameDataFmt = AudioFrameDataFmt
+    ten_runtime.Cmd = Cmd
+    ten_runtime.CmdResult = CmdResult
+    ten_runtime.StatusCode = StatusCode
+
+    async_ten_env_module = types.ModuleType("ten_runtime.async_ten_env")
+    async_ten_env_module.AsyncTenEnv = AsyncTenEnv
+
+    audio_frame_module = types.ModuleType("ten_runtime.audio_frame")
+    audio_frame_module.AudioFrame = AudioFrame
+    audio_frame_module.AudioFrameDataFmt = AudioFrameDataFmt
+
+    cmd_module = types.ModuleType("ten_runtime.cmd")
+    cmd_module.Cmd = Cmd
+
+    cmd_result_module = types.ModuleType("ten_runtime.cmd_result")
+    cmd_result_module.CmdResult = CmdResult
+    cmd_result_module.StatusCode = StatusCode
+
+    return {
+        "ten_runtime": ten_runtime,
+        "ten_runtime.async_ten_env": async_ten_env_module,
+        "ten_runtime.audio_frame": audio_frame_module,
+        "ten_runtime.cmd": cmd_module,
+        "ten_runtime.cmd_result": cmd_result_module,
+    }
+
+
+def _load_module(module_name: str, file_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module {module_name}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_feature_reporting_symbols():
+    fake_runtime_modules = _create_fake_ten_runtime_modules()
+    original_runtime_modules = {
+        name: sys.modules.get(name) for name in fake_runtime_modules
+    }
+    sys.modules.update(fake_runtime_modules)
+
+    package_root = (
+        Path(__file__).resolve().parents[1] / "interface" / "ten_ai_base"
+    )
+    package_name = "ten_ai_base"
+    package_module_names = [
+        package_name,
+        f"{package_name}.const",
+        f"{package_name}.message",
+        f"{package_name}.helper",
+        f"{package_name}.struct",
+        f"{package_name}.types",
+        f"{package_name}.connection_status",
+        f"{package_name}.timeline",
+        f"{package_name}.utils",
+        f"{package_name}.features",
+        f"{package_name}.asr",
+        f"{package_name}.tts2",
+    ]
+    original_package_modules = {
+        name: sys.modules.get(name) for name in package_module_names
+    }
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(package_root)]
+    sys.modules[package_name] = package
+
+    try:
+        for module in [
+            "const",
+            "message",
+            "helper",
+            "struct",
+            "types",
+            "connection_status",
+            "timeline",
+            "utils",
+            "features",
+            "asr",
+            "tts2",
+        ]:
+            _load_module(
+                f"{package_name}.{module}", package_root / f"{module}.py"
+            )
+
+        return {
+            "AsyncASRBaseExtension": sys.modules[
+                f"{package_name}.asr"
+            ].AsyncASRBaseExtension,
+            "AsyncTTS2BaseExtension": sys.modules[
+                f"{package_name}.tts2"
+            ].AsyncTTS2BaseExtension,
+            "ProvideFeaturesPayload": sys.modules[
+                f"{package_name}.message"
+            ].ProvideFeaturesPayload,
+            "DATA_OUT_PROVIDE_FEATURES": sys.modules[
+                f"{package_name}.const"
+            ].DATA_OUT_PROVIDE_FEATURES,
+            "send_provide_features": sys.modules[
+                f"{package_name}.features"
+            ].send_provide_features,
+        }
+    finally:
+        for name, module in original_package_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        for name, module in original_runtime_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+SYMBOLS = _load_feature_reporting_symbols()
+AsyncASRBaseExtension = SYMBOLS["AsyncASRBaseExtension"]
+AsyncTTS2BaseExtension = SYMBOLS["AsyncTTS2BaseExtension"]
+ProvideFeaturesPayload = SYMBOLS["ProvideFeaturesPayload"]
+DATA_OUT_PROVIDE_FEATURES = SYMBOLS["DATA_OUT_PROVIDE_FEATURES"]
+send_provide_features = SYMBOLS["send_provide_features"]
+
+
+def _make_mock_ten_env(sent_data: list[tuple[str, dict]]) -> MagicMock:
+    async def capture_send_data(data) -> None:
+        payload = json.loads(data.get_property_to_json(None)[0])
+        sent_data.append((data.get_name(), payload))
+
+    ten_env = MagicMock()
+    ten_env.send_data = AsyncMock(side_effect=capture_send_data)
+    ten_env.log_info = MagicMock()
+    ten_env.log_warn = MagicMock()
+    ten_env.log_debug = MagicMock()
+    ten_env.log_error = MagicMock()
+    return ten_env
+
+
+async def _cancel_task(task: asyncio.Task | None) -> None:
+    if task is None:
+        return
+
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
+class _FeatureASRExtension(AsyncASRBaseExtension):
+    def vendor(self) -> str:
+        return "feature-asr"
+
+    async def start_connection(self) -> None:
+        return None
+
+    def is_connected(self) -> bool:
+        return False
+
+    async def stop_connection(self) -> None:
+        return None
+
+    async def send_audio(self, frame, session_id: str | None) -> bool:
+        return True
+
+    async def finalize(self, session_id: str | None) -> None:
+        return None
+
+    def input_audio_sample_rate(self) -> int:
+        return 16000
+
+
+class _FeatureTTSExtension(AsyncTTS2BaseExtension):
+    def vendor(self) -> str:
+        return "feature-tts"
+
+    async def request_tts(self, t) -> None:
+        return None
+
+    def synthesize_audio_sample_rate(self) -> int:
+        return 16000
+
+
+def test_send_provide_features_emits_expected_payload():
+    asyncio.run(async_test_send_provide_features_emits_expected_payload())
+
+
+async def async_test_send_provide_features_emits_expected_payload():
+    sent_data: list[tuple[str, dict]] = []
+    ten_env = _make_mock_ten_env(sent_data)
+
+    await send_provide_features(ten_env, {"asr.vendor": "feature-asr"})
+
+    assert sent_data == [
+        (
+            DATA_OUT_PROVIDE_FEATURES,
+            ProvideFeaturesPayload(
+                features={"asr.vendor": "feature-asr"}
+            ).model_dump(),
+        )
+    ]
+
+
+def test_asr_on_start_reports_vendor_feature():
+    asyncio.run(async_test_asr_on_start_reports_vendor_feature())
+
+
+async def async_test_asr_on_start_reports_vendor_feature():
+    sent_data: list[tuple[str, dict]] = []
+    ext = _FeatureASRExtension("feature-asr")
+    ext.ten_env = _make_mock_ten_env(sent_data)
+    ext.auto_connect = False
+
+    try:
+        await ext.on_start(ext.ten_env)
+        assert sent_data[0] == (
+            DATA_OUT_PROVIDE_FEATURES,
+            {"features": {"asr.vendor": "feature-asr"}},
+        )
+    finally:
+        await _cancel_task(ext.audio_actual_send_metrics_task)
+
+
+def test_tts2_on_start_reports_vendor_feature():
+    asyncio.run(async_test_tts2_on_start_reports_vendor_feature())
+
+
+async def async_test_tts2_on_start_reports_vendor_feature():
+    sent_data: list[tuple[str, dict]] = []
+    ext = _FeatureTTSExtension("feature-tts")
+    ten_env = _make_mock_ten_env(sent_data)
+
+    try:
+        await ext.on_start(ten_env)
+        assert sent_data[0] == (
+            DATA_OUT_PROVIDE_FEATURES,
+            {"features": {"tts.vendor": "feature-tts"}},
+        )
+    finally:
+        await _cancel_task(ext.loop_task)


### PR DESCRIPTION
Expose the `provide_features` payload in the ASR, avatar, LLM, MLLM, and TTS interface schemas. Add a shared helper plus payload model, and report vendor features during ASR and TTS startup. Cover the new payload and startup reporting flow with feature reporting tests.