### PR TITLE
feat: add TTS request reporting metrics

### DIFF
--- a/interface/ten_ai_base/tts2.py
+++ b/interface/ten_ai_base/tts2.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 import asyncio
 from enum import Enum
 import json
+import time
 import traceback
 from typing import final
 import uuid
@@ -56,6 +57,7 @@ class RequestState(Enum):
     - FINALIZING: All text received (text_input_end=True), generating final audio
     - COMPLETED: Terminal state - request finished (check TTSAudioEndReason for completion reason)
     """
+
     QUEUED = "queued"
     PROCESSING = "processing"
     FINALIZING = "finalizing"
@@ -81,7 +83,9 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
         self.leftover_bytes = b""
         self.session_id = None
         self.metadatas = {}
-        self._flush_complete_event = asyncio.Event()  # allow get after flush is complete
+        self._flush_complete_event = (
+            asyncio.Event()
+        )  # allow get after flush is complete
         self._flush_complete_event.set()  # Initially allow gets
         self._put_lock = asyncio.Lock()  # Protect put operations from race conditions
 
@@ -132,7 +136,9 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
 
         return new_state in valid_transitions.get(current_state, [])
 
-    def _transition_state(self, request_id: str, new_state: RequestState, reason: str = "") -> bool:
+    def _transition_state(
+        self, request_id: str, new_state: RequestState, reason: str = ""
+    ) -> bool:
         """
         Transition request to a new state with validation and logging.
         Returns True if transition succeeded, False otherwise.
@@ -161,7 +167,8 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
         COMPLETED states indefinitely. Flush operation will also clear all states.
         """
         completed_ids = [
-            req_id for req_id, state in self.request_states.items()
+            req_id
+            for req_id, state in self.request_states.items()
             if state == RequestState.COMPLETED
         ]
 
@@ -220,9 +227,7 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
             except Exception as e:
                 ten_env.log_error(f"update_configs failed: {e}")
                 cmd_result = CmdResult.create(StatusCode.ERROR, cmd)
-                cmd_result.set_property_from_json(
-                    "", json.dumps({"message": str(e)})
-                )
+                cmd_result.set_property_from_json("", json.dumps({"message": str(e)}))
                 await ten_env.return_result(cmd_result)
         else:
             cmd_result = CmdResult.create(StatusCode.OK, cmd)
@@ -253,17 +258,19 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
             # Use lock to prevent race condition between wait and put
             async with self._put_lock:
                 await self._flush_complete_event.wait()
-                
+
                 # Record QUEUED state after flush check to avoid race condition
                 # This ensures metadata is set atomically with queue put operation
                 if t.request_id not in self.request_states:
                     # Clean up old COMPLETED states to prevent unbounded growth
                     self._cleanup_completed_states()
 
-                    self._transition_state(t.request_id, RequestState.QUEUED, "request received")
+                    self._transition_state(
+                        t.request_id, RequestState.QUEUED, "request received"
+                    )
                     if t.metadata:
                         self.metadatas[t.request_id] = t.metadata
-                
+
                 self.ten_env.log_debug(f"on_data tts_text_input put to queue")
                 await self.input_queue.put(t)
         if data.get_name() == DATA_FLUSH:
@@ -346,8 +353,9 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
         self._processing_request_id = None
         self.current_audio_request_id = None
 
-        self.ten_env.log_debug("Cleared all request states, metadata, and pending messages after flush")
-
+        self.ten_env.log_debug(
+            "Cleared all request states, metadata, and pending messages after flush"
+        )
 
     async def _cancel_current_task(self) -> None:
         """Called when the TTS request is cancelled."""
@@ -412,9 +420,12 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
             try:
                 if t.text_input_end:
                     self._transition_state(
-                        t.request_id, RequestState.FINALIZING,
-                        "received text_input_end, generating final audio"
+                        t.request_id,
+                        RequestState.FINALIZING,
+                        "received text_input_end, generating final audio",
                     )
+                if t.text_input_end and not t.text:
+                    await self.send_tts_request_final_marker(t.request_id)
                 await self.request_tts(t)
 
             except asyncio.CancelledError:
@@ -455,7 +466,10 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
                 )
                 f.alloc_buf(len(combined_data))
                 f.set_timestamp(timestamp)
-                f.set_property_from_json("metadata", json.dumps(self.metadatas.get(self.current_audio_request_id, {})))
+                f.set_property_from_json(
+                    "metadata",
+                    json.dumps(self.metadatas.get(self.current_audio_request_id, {})),
+                )
                 buff = f.lock_buf()
                 buff[:] = combined_data
                 f.unlock_buf(buff)
@@ -539,7 +553,7 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
             category=LOG_CATEGORY_KEY_POINT,
         )
         await self.ten_env.send_data(data)
- 
+
         # Reset current_audio_request_id (audio phase complete)
         if self.current_audio_request_id == request_id:
             self.current_audio_request_id = None
@@ -556,9 +570,7 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
             combined_metadata.update(error.metadata)
         if extra_metadata:
             combined_metadata.update(extra_metadata)
-        new_metadata = self.update_metadata(
-            request_id, combined_metadata or None
-        )
+        new_metadata = self.update_metadata(request_id, combined_metadata or None)
         """
         Send an error message related to TTS processing.
         """
@@ -627,6 +639,55 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
         data.set_property_from_json(None, metrics.model_dump_json())
         await self.ten_env.send_data(data)
 
+    async def send_tts_request_metrics(
+        self,
+        request_id: str,
+        output_characters: int,
+        *,
+        request_time_ms: int | None = None,
+        request_final: bool = False,
+        extra_metadata: dict | None = None,
+    ) -> None:
+        metadata = self.update_metadata(request_id, extra_metadata)
+        metadata["request_id"] = request_id
+        metadata["request_final"] = request_final
+        metrics = ModuleMetrics(
+            id=self.get_uuid(),
+            module=ModuleType.TTS,
+            vendor=self.vendor(),
+            metrics={
+                ModuleMetricKey.REQUEST_TIME_MS: (
+                    request_time_ms
+                    if request_time_ms is not None
+                    else int(time.time() * 1000)
+                ),
+                ModuleMetricKey.REQUEST_BYTES: (
+                    output_characters
+                    if isinstance(output_characters, int) and output_characters >= 0
+                    else 0
+                ),
+                ModuleMetricKey.RESPONSE_TIME_MS: 0,
+                ModuleMetricKey.RESPONSE_BYTES: 0,
+            },
+            metadata=metadata,
+        )
+        await self.send_metrics(metrics, request_id)
+
+    async def send_tts_request_final_marker(self, request_id: str) -> None:
+        metadata = self.update_metadata(request_id, None)
+        metadata["request_id"] = request_id
+        metadata["request_final"] = True
+        await self.send_metrics(
+            ModuleMetrics(
+                id=self.get_uuid(),
+                module=ModuleType.TTS,
+                vendor=self.vendor(),
+                metrics={},
+                metadata=metadata,
+            ),
+            request_id,
+        )
+
     async def metrics_calculate_duration(self) -> None:
         self.recv_audio_duration = (
             self.recv_audio_chunks_len
@@ -660,7 +721,10 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
         self.recv_audio_chunks_len = 0
 
     async def metrics_connect_delay(
-        self, connect_delay_ms: int, extra_metadata: dict | None = None, request_id: str = ""
+        self,
+        connect_delay_ms: int,
+        extra_metadata: dict | None = None,
+        request_id: str = "",
     ):
         new_metadata = self.update_metadata(request_id, extra_metadata)
         metrics = ModuleMetrics(
@@ -917,21 +981,25 @@ class AsyncTTS2BaseExtension(AsyncExtension, ABC):
         """
         return uuid.uuid4().hex
 
-    def update_metadata(self, request_id: str| None, metadata: dict | None) -> dict:
+    def update_metadata(self, request_id: str | None, metadata: dict | None) -> dict:
         new_metadata = {}
         if request_id and request_id in self.metadatas:
             new_metadata = self.metadatas.get(request_id).copy()
         if metadata:
             new_metadata.update(metadata)
-        vendor_metadata = redact_json(self.vendor_metadata() or {})
+        vendor_metadata = self.vendor_metadata() or {}
         if vendor_metadata:
             existing_vendor_metadata = new_metadata.get(VENDOR_METADATA_KEY, {})
             if isinstance(existing_vendor_metadata, dict):
                 merged_vendor_metadata = existing_vendor_metadata.copy()
                 merged_vendor_metadata.update(vendor_metadata)
-                new_metadata[VENDOR_METADATA_KEY] = merged_vendor_metadata
+                new_metadata[VENDOR_METADATA_KEY] = redact_json(merged_vendor_metadata)
             else:
-                new_metadata[VENDOR_METADATA_KEY] = vendor_metadata
+                new_metadata[VENDOR_METADATA_KEY] = redact_json(vendor_metadata)
+        elif isinstance(new_metadata.get(VENDOR_METADATA_KEY), dict):
+            new_metadata[VENDOR_METADATA_KEY] = redact_json(
+                new_metadata[VENDOR_METADATA_KEY]
+            )
         return new_metadata
 
     async def cancel_tts(self) -> None:

--- a/interface/ten_ai_base/tts2_http.py
+++ b/interface/ten_ai_base/tts2_http.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 import asyncio
 from datetime import datetime
 import os
+import time
 import traceback
 from typing import Any, AsyncIterator, Tuple
 
@@ -42,6 +43,7 @@ class AsyncTTS2HttpConfig(BaseModel):
     def validate(self) -> None:
         raise NotImplementedError("validate is not implemented")
 
+
 class AsyncTTS2HttpClient:
     @abstractmethod
     async def clean(self) -> None:
@@ -52,7 +54,9 @@ class AsyncTTS2HttpClient:
         raise NotImplementedError("cancel is not implemented")
 
     @abstractmethod
-    async def get(self, text: str, request_id: str) -> AsyncIterator[Tuple[bytes | None, TTS2HttpResponseEventType]]:
+    async def get(
+        self, text: str, request_id: str
+    ) -> AsyncIterator[Tuple[bytes | None, TTS2HttpResponseEventType]]:
         raise NotImplementedError("get is not implemented")
 
     @abstractmethod
@@ -65,9 +69,10 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
     async def create_config(self, config_json_str: str) -> AsyncTTS2HttpConfig:
         raise NotImplementedError("create_config is not implemented")
 
-
     @abstractmethod
-    async def create_client(self, config: AsyncTTS2HttpConfig, ten_env: AsyncTenEnv) -> AsyncTTS2HttpClient:
+    async def create_client(
+        self, config: AsyncTTS2HttpConfig, ten_env: AsyncTenEnv
+    ) -> AsyncTTS2HttpClient:
         raise NotImplementedError("create_client is not implemented")
 
     def __init__(self, name: str) -> None:
@@ -81,9 +86,9 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
         self.current_request_finished: bool = False
         self.total_audio_bytes: int = 0
         self.first_chunk: bool = False
-        self.recorder_map: dict[str, PCMWriter] = (
-            {}
-        )  # Store PCMWriter instances for different request_ids
+        self.recorder_map: dict[
+            str, PCMWriter
+        ] = {}  # Store PCMWriter instances for different request_ids
 
     async def on_init(self, ten_env: AsyncTenEnv) -> None:
         try:
@@ -142,9 +147,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                 # Remove from map after successful flush
                 if request_id in self.recorder_map:
                     del self.recorder_map[request_id]
-                ten_env.log_debug(
-                    f"Flushed PCMWriter for request_id: {request_id}"
-                )
+                ten_env.log_debug(f"Flushed PCMWriter for request_id: {request_id}")
             except Exception as e:
                 ten_env.log_error(
                     f"Error flushing PCMWriter for request_id {request_id}: {e}"
@@ -203,9 +206,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                 f"current_request_id: {self.current_request_id}, new request_id: {t.request_id}, current_request_finished: {self.current_request_finished}"
             )
             if t.request_id != self.current_request_id:
-                self.ten_env.log_debug(
-                    f"New TTS request with ID: {t.request_id}"
-                )
+                self.ten_env.log_debug(f"New TTS request with ID: {t.request_id}")
                 self.first_chunk = True
                 self.sent_ts = datetime.now()
                 self.request_ts = None
@@ -219,9 +220,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                 if self.config and self.config.dump:
                     # Clean up old PCMWriters (except current request_id)
                     old_request_ids = [
-                        rid
-                        for rid in self.recorder_map.keys()
-                        if rid != t.request_id
+                        rid for rid in self.recorder_map.keys() if rid != t.request_id
                     ]
                     for old_rid in old_request_ids:
                         try:
@@ -241,9 +240,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                             self.config.dump_path,
                             f"{self.vendor()}_dump_{t.request_id}.pcm",
                         )
-                        self.recorder_map[t.request_id] = PCMWriter(
-                            dump_file_path
-                        )
+                        self.recorder_map[t.request_id] = PCMWriter(dump_file_path)
                         self.ten_env.log_debug(
                             f"Created PCMWriter for request_id: {t.request_id}, file: {dump_file_path}"
                         )
@@ -254,9 +251,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                 return
 
             if t.text_input_end:
-                self.ten_env.log_debug(
-                    f"finish session for request ID: {t.request_id}"
-                )
+                self.ten_env.log_debug(f"finish session for request ID: {t.request_id}")
                 self.current_request_finished = True
 
             # Track character metrics
@@ -267,7 +262,15 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                 f"send_text_to_tts_server:  {t.text} of request_id: {t.request_id}",
                 category=LOG_CATEGORY_VENDOR,
             )
+            request_time_ms = int(time.time() * 1000)
             data = self.client.get(t.text, t.request_id)
+            if t.text:
+                await self.send_tts_request_metrics(
+                    request_id=t.request_id,
+                    request_time_ms=request_time_ms,
+                    output_characters=len(t.text),
+                    request_final=t.text_input_end,
+                )
 
             chunk_count = 0
 
@@ -290,9 +293,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                                     request_id=self.current_request_id,
                                 )
                                 ttfb = int(
-                                    (
-                                        datetime.now() - self.sent_ts
-                                    ).total_seconds()
+                                    (datetime.now() - self.sent_ts).total_seconds()
                                     * 1000
                                 )
                                 extra_metadata = self.client.get_extra_metadata()
@@ -316,9 +317,9 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                             self.ten_env.log_debug(
                                 f"Writing audio chunk to dump file, dump url: {self.config.dump_path}"
                             )
-                            await self.recorder_map[
-                                self.current_request_id
-                            ].write(audio_chunk)
+                            await self.recorder_map[self.current_request_id].write(
+                                audio_chunk
+                            )
 
                         # Track audio metrics
                         self.metrics_add_recv_audio_chunks(audio_chunk)
@@ -329,9 +330,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                         self.ten_env.log_debug(
                             "Received empty payload for TTS response"
                         )
-                        if self._current_request_needs_audio_end(
-                            t.text_input_end
-                        ):
+                        if self._current_request_needs_audio_end(t.text_input_end):
                             await self._send_audio_end_and_finish(
                                 request_id=self.current_request_id,
                                 reason=TTSAudioEndReason.REQUEST_END,
@@ -339,13 +338,9 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                             )
 
                 elif event_status == TTS2HttpResponseEventType.END:
-                    self.ten_env.log_debug(
-                        "Received TTS_END event from TTS"
-                    )
+                    self.ten_env.log_debug("Received TTS_END event from TTS")
                     # Send TTS audio end event
-                    if self._current_request_needs_audio_end(
-                        t.text_input_end
-                    ):
+                    if self._current_request_needs_audio_end(t.text_input_end):
                         await self._send_audio_end_and_finish(
                             request_id=self.current_request_id,
                             reason=TTSAudioEndReason.REQUEST_END,
@@ -366,9 +361,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                             message=error_msg,
                             module=ModuleType.TTS,
                             code=ModuleErrorCode.FATAL_ERROR,
-                            vendor_info=ModuleErrorVendorInfo(
-                                vendor=self.vendor()
-                            ),
+                            vendor_info=ModuleErrorVendorInfo(vendor=self.vendor()),
                         ),
                         text_input_end=t.text_input_end,
                     )
@@ -387,9 +380,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                             message=error_msg,
                             module=ModuleType.TTS,
                             code=ModuleErrorCode.NON_FATAL_ERROR,
-                            vendor_info=ModuleErrorVendorInfo(
-                                vendor=self.vendor()
-                            ),
+                            vendor_info=ModuleErrorVendorInfo(vendor=self.vendor()),
                         ),
                         text_input_end=t.text_input_end,
                     )
@@ -398,7 +389,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
             self.ten_env.log_debug(
                 f"TTS processing completed, total chunks: {chunk_count}"
             )
-            
+
             # Handle case where loop ended normally but we didn't receive END event
             # This can happen if the stream ends without an explicit END event
             if self._current_request_needs_audio_end(t.text_input_end):
@@ -412,9 +403,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                 )
 
         except Exception as e:
-            self.ten_env.log_error(
-                f"Error in request_tts: {traceback.format_exc()}"
-            )
+            self.ten_env.log_error(f"Error in request_tts: {traceback.format_exc()}")
             request_id = self.current_request_id or t.request_id
             await self._handle_error_with_text_input_end(
                 request_id=request_id,
@@ -441,17 +430,14 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
         """Calculate request event interval in milliseconds."""
         start_ts = self.request_ts or self.sent_ts
         if start_ts:
-            return int(
-                (datetime.now() - start_ts).total_seconds() * 1000
-            )
+            return int((datetime.now() - start_ts).total_seconds() * 1000)
         return 0
 
     def _current_request_needs_audio_end(self, text_input_end: bool) -> bool:
         if not text_input_end or not self.current_request_id:
             return False
         return (
-            self.request_states.get(self.current_request_id)
-            == RequestState.FINALIZING
+            self.request_states.get(self.current_request_id) == RequestState.FINALIZING
         )
 
     async def _send_audio_end_and_finish(
@@ -462,7 +448,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
     ) -> None:
         """
         Send tts_audio_end event and finish the request.
-        
+
         Args:
             request_id: The request ID
             reason: The reason for ending the audio
@@ -470,10 +456,10 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
         """
         request_event_interval = self._calculate_request_event_interval_ms()
         duration_ms = self._calculate_audio_duration_ms()
-        
+
         if log_message:
             self.ten_env.log_debug(log_message)
-        
+
         await self.send_tts_audio_end(
             request_id=request_id,
             request_event_interval_ms=request_event_interval,
@@ -496,7 +482,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
                 self.ten_env.log_error(
                     f"Error closing PCMWriter for request_id {request_id}: {e}"
                 )
-        
+
         await self.finish_request(
             request_id=request_id,
             reason=reason,
@@ -510,7 +496,7 @@ class AsyncTTS2HttpExtension(AsyncTTS2BaseExtension):
     ) -> None:
         """
         Handle error and send tts_audio_end if text_input_end was received.
-        
+
         Args:
             request_id: The request ID
             error: The error to send

--- a/interface/ten_ai_base/utils.py
+++ b/interface/ten_ai_base/utils.py
@@ -32,10 +32,16 @@ DEFAULT_JSON_KEYS = frozenset(
     | DEFAULT_HEADER_KEYS
 )
 DEFAULT_URL_KEYS = frozenset({"sign", "signature"} | DEFAULT_JSON_KEYS)
+_MASKED_SECRET_PATTERN = re.compile(
+    r"^.{1,5}\.\.\..{1,5}#[0-9a-f]{8}$",
+    re.DOTALL,
+)
 
 
 def _mask_default(value: str) -> str:
     if not value:
+        return value
+    if _MASKED_SECRET_PATTERN.fullmatch(value):
         return value
     step = int(len(value) / 5)
     if step <= 0:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "system",
   "name": "ten_ai_base",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "package": {
     "include": [
       "manifest.json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ten_ai_base"
-version = "0.7.57"
+version = "0.7.58"
 description = "TEN Framework base AI module"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_tts2_http.py
+++ b/tests/test_tts2_http.py
@@ -112,9 +112,7 @@ def _load_tts2_http_symbols():
     }
     sys.modules.update(fake_runtime_modules)
 
-    package_root = (
-        Path(__file__).resolve().parents[1] / "interface" / "ten_ai_base"
-    )
+    package_root = Path(__file__).resolve().parents[1] / "interface" / "ten_ai_base"
     package_name = "ten_ai_base"
     package_module_names = [
         package_name,
@@ -145,9 +143,7 @@ def _load_tts2_http_symbols():
             "tts2",
             "tts2_http",
         ]:
-            _load_module(
-                f"{package_name}.{module}", package_root / f"{module}.py"
-            )
+            _load_module(f"{package_name}.{module}", package_root / f"{module}.py")
 
         return {
             "AsyncTTS2HttpClient": sys.modules[
@@ -159,27 +155,19 @@ def _load_tts2_http_symbols():
             "AsyncTTS2HttpExtension": sys.modules[
                 f"{package_name}.tts2_http"
             ].AsyncTTS2HttpExtension,
-            "RequestState": sys.modules[
-                f"{package_name}.tts2"
-            ].RequestState,
+            "RequestState": sys.modules[f"{package_name}.tts2"].RequestState,
             "ModuleConnectionStatus": sys.modules[
                 f"{package_name}.message"
             ].ModuleConnectionStatus,
-            "ModuleError": sys.modules[
-                f"{package_name}.message"
-            ].ModuleError,
+            "ModuleError": sys.modules[f"{package_name}.message"].ModuleError,
             "TTSAudioEndReason": sys.modules[
                 f"{package_name}.message"
             ].TTSAudioEndReason,
             "TTS2HttpResponseEventType": sys.modules[
                 f"{package_name}.struct"
             ].TTS2HttpResponseEventType,
-            "TTSTextInput": sys.modules[
-                f"{package_name}.struct"
-            ].TTSTextInput,
-            "mask_secret": sys.modules[
-                f"{package_name}.utils"
-            ].mask_secret,
+            "TTSTextInput": sys.modules[f"{package_name}.struct"].TTSTextInput,
+            "mask_secret": sys.modules[f"{package_name}.utils"].mask_secret,
         }
     finally:
         for name, module in original_package_modules.items():
@@ -255,6 +243,13 @@ class FakeHttpClient(AsyncTTS2HttpClient):
 
     def get_extra_metadata(self) -> dict[str, str]:
         return self.extra_metadata
+
+
+class FailingHttpClient(FakeHttpClient):
+    async def get(self, text: str, request_id: str):
+        if False:
+            yield None
+        raise RuntimeError("vendor request failed")
 
 
 class RecordingHttpExtension(AsyncTTS2HttpExtension):
@@ -389,7 +384,10 @@ def test_vendor_metadata_is_added_to_metrics_and_errors():
     extension = RecordingHttpExtension([])
     extension.metadatas["req"] = {
         "session_id": "session-1",
-        "vendor_metadata": {"region": "us"},
+        "vendor_metadata": {
+            "region": "us",
+            "api_key": "existing-secret-5678",
+        },
     }
 
     _run(extension.metrics_connect_delay(42, request_id="req"))
@@ -411,6 +409,7 @@ def test_vendor_metadata_is_added_to_metrics_and_errors():
         "session_id": "session-1",
         "vendor_metadata": {
             "region": "us",
+            "api_key": mask_secret("existing-secret-5678"),
             "key": mask_secret("sk-test-secret-1234"),
             "url": "wss://tts.example",
         },
@@ -420,16 +419,123 @@ def test_vendor_metadata_is_added_to_metrics_and_errors():
         "turn_id": 7,
         "vendor_metadata": {
             "region": "us",
+            "api_key": mask_secret("existing-secret-5678"),
             "key": mask_secret("sk-test-secret-1234"),
             "url": "wss://tts.example",
         },
     }
 
 
-def test_zero_audio_end_finishes_without_audio_start():
-    extension = RecordingHttpExtension(
-        [(None, TTS2HttpResponseEventType.END)]
+def test_http_vendor_attempt_emits_request_metrics():
+    extension = RecordingHttpExtension([(None, TTS2HttpResponseEventType.END)])
+    _mark_request_finalizing(extension, "request-metrics")
+
+    _run(
+        extension.request_tts(
+            TTSTextInput(
+                request_id="request-metrics",
+                text="hello",
+                text_input_end=True,
+                metadata={"session_id": "session-1", "turn_id": 7},
+            )
+        )
     )
+
+    metrics_payloads = [
+        _data_payload(data)
+        for data in extension.ten_env.sent_data
+        if data.name == "metrics"
+    ]
+    request_metrics = next(
+        payload
+        for payload in metrics_payloads
+        if "request_time_ms" in payload["metrics"]
+    )
+    assert request_metrics["module"] == "tts"
+    assert request_metrics["vendor"] == "test_vendor"
+    assert request_metrics["metrics"]["request_time_ms"] > 0
+    assert request_metrics["metrics"]["request_bytes"] == 5
+    assert request_metrics["metrics"]["response_time_ms"] == 0
+    assert request_metrics["metrics"]["response_bytes"] == 0
+    assert request_metrics["metadata"]["request_id"] == "request-metrics"
+    assert request_metrics["metadata"]["request_final"] is True
+
+
+def test_final_marker_has_no_request_metric_values():
+    extension = RecordingHttpExtension([])
+    extension.metadatas["final-marker"] = {"session_id": "session-1"}
+
+    _run(extension.send_tts_request_final_marker("final-marker"))
+
+    payload = _data_payload(extension.ten_env.sent_data[0])
+    assert payload["metrics"] == {}
+    assert payload["metadata"]["request_id"] == "final-marker"
+    assert payload["metadata"]["request_final"] is True
+
+
+def test_empty_final_marker_is_sent_before_provider_processing():
+    class MarkerOrderExtension(RecordingHttpExtension):
+        def __init__(self) -> None:
+            super().__init__([])
+            self.events = []
+
+        async def send_tts_request_final_marker(self, request_id: str) -> None:
+            self.events.append(("marker", request_id))
+
+        async def request_tts(self, t: TTSTextInput) -> None:
+            self.events.append(("provider", t.request_id))
+
+    extension = MarkerOrderExtension()
+    extension.request_states["empty-final"] = RequestState.QUEUED
+
+    async def process() -> None:
+        await extension.input_queue.put(
+            TTSTextInput(
+                request_id="empty-final",
+                text="",
+                text_input_end=True,
+                metadata={},
+            )
+        )
+        await extension.input_queue.put(None)
+        await extension._process_input_queue(extension.ten_env)
+
+    _run(process())
+
+    assert extension.events == [
+        ("marker", "empty-final"),
+        ("provider", "empty-final"),
+    ]
+
+
+def test_http_vendor_failure_still_emits_request_metrics():
+    extension = RecordingHttpExtension([])
+    extension.client = FailingHttpClient([])
+    _mark_request_finalizing(extension, "failed-request")
+
+    _run(
+        extension.request_tts(
+            TTSTextInput(
+                request_id="failed-request",
+                text="failed text",
+                text_input_end=True,
+                metadata={},
+            )
+        )
+    )
+
+    metrics_payloads = [
+        _data_payload(data)
+        for data in extension.ten_env.sent_data
+        if data.name == "metrics"
+    ]
+    assert any(
+        payload["metrics"].get("request_bytes") == 11 for payload in metrics_payloads
+    )
+
+
+def test_zero_audio_end_finishes_without_audio_start():
+    extension = RecordingHttpExtension([(None, TTS2HttpResponseEventType.END)])
     extension.request_ts = datetime(2000, 1, 1)
     _mark_request_finalizing(extension, "silent-final")
 
@@ -457,9 +563,7 @@ def test_zero_audio_end_finishes_without_audio_start():
 
 
 def test_zero_audio_end_releases_next_queued_request():
-    extension = RecordingHttpExtension(
-        [(None, TTS2HttpResponseEventType.END)]
-    )
+    extension = RecordingHttpExtension([(None, TTS2HttpResponseEventType.END)])
     next_request = TTSTextInput(
         request_id="next-request",
         text="queued",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,13 @@ def test_mask_secret_masks_long_values():
     assert mask_secret("abcdefghijklmnopqrstuvwxyz") == "abcde...vwxyz#71c480df"
 
 
+def test_mask_secret_does_not_mask_its_own_output_twice():
+    masked = mask_secret("abcdef123456")
+
+    assert mask_secret(masked) == masked
+    assert redact_json({"api_key": masked})["api_key"] == masked
+
+
 def test_mask_secret_keeps_short_values():
     assert mask_secret("") == ""
     assert mask_secret("a") == "a"


### PR DESCRIPTION
## Summary

- add common TTS request-level metrics and an empty final marker
- report HTTP vendor attempts with request bytes derived from output characters
- merge vendor metadata before final redaction and keep masking idempotent
- bump ten_ai_base from 0.7.57 to 0.7.58

## Testing

- `uv run pytest --noconftest tests/test_tts2_http.py -q` (11 passed)
- `tests/test_utils.py` in the TEN Linux container (47 passed)